### PR TITLE
OAuth Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .serverless
 node_modules/
 __pycache__/
+# ignore credentials for security
+credentials.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# api
+# spotify chatbot api
+
 Run using this command in terminal:
 uvicorn main:app --reload
 
 docker build -t spotify-chatbot-api-image .
+
+## Other required setup
+
+Download the `credentials.json` from the google drive and put it in the `/api` folder.

--- a/credentials.json
+++ b/credentials.json
@@ -1,4 +1,0 @@
-{
-    "spotify_client_id": "KEY",
-    "spotify_client_secret": "KEY"
-}

--- a/credentials.json
+++ b/credentials.json
@@ -1,0 +1,4 @@
+{
+    "spotify_client_id": "KEY",
+    "spotify_client_secret": "KEY"
+}

--- a/main.py
+++ b/main.py
@@ -1,5 +1,10 @@
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
+import string
+import random
+import json
+import requests
 
 app = FastAPI()
 
@@ -16,10 +21,24 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+creds = json.load(open('credentials.json')) # load in creds from json file
+
+app.scope = "user-read-private user-read-email user-top-read"
+app.state = '' # TODO update api to work with multiple users, this should be per user not global. Still could work with multiple user might be issues if multiple are signing in at the same time
+
 @app.get("/")
 async def root():
     return {"message": "api is running"}
 
-@app.get("/hello-world")
+@app.get("/spotify-login")
 async def root():
-    return {"message": "Hello World"}
+    app.state = ''.join(random.choices(string.ascii_letters + string.digits, k=16))
+    authorizeLink = 'https://accounts.spotify.com/authorize?response_type=code&client_id=' + creds['spotify_client_id'] + '&scope=' + app.scope + '&redirect_uri=http://localhost:8000/callback&state=' + app.state
+    return RedirectResponse(authorizeLink, status_code=303)
+
+@app.get("/callback")
+async def root(code: str, state: str):
+    if (state != app.state):
+        return {"message": "state_mismatch"}
+    else:
+        app.state = ""

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ app.add_middleware(
 
 creds = json.load(open('credentials.json')) # load in creds from json file
 
-app.scope = "user-read-private user-read-email user-top-read"
+app.scope = "user-read-private user-read-email user-top-read" # This is the scope for what info we request access to on spotify, make sure to add more to it if you need more data
 app.state = '' # TODO update api to work with multiple users, this should be per user not global. Still could work with multiple user might be issues if multiple are signing in at the same time
 app.access_token = ''
 app.refresh_token = ''
@@ -36,7 +36,9 @@ async def root():
 # Endpoint that generates the authorization url for the user
 @app.get("/spotify-login")
 async def root():
+    # random state to check if callback request is legitimate
     app.state = ''.join(random.choices(string.ascii_letters + string.digits, k=16))
+    # builds auth url from credentials and scope
     authorizeLink = 'https://accounts.spotify.com/authorize?response_type=code&client_id=' + creds['spotify_client_id'] + '&scope=' + app.scope + '&redirect_uri=http://localhost:8000/callback&state=' + app.state
     return { "auth_url": authorizeLink }
 

--- a/main.py
+++ b/main.py
@@ -78,10 +78,11 @@ async def root():
     user_params = {
         "limit": 50
     }
-    user_info = requests.get("https://api.spotify.com/v1/me", params=user_params, headers=user_headers)
-    return { "username": user_info.json()['display_name'], "profile_pic": user_info.json()['images'] }
+    user_info_response = requests.get("https://api.spotify.com/v1/me", params=user_params, headers=user_headers)
+    user_info = user_info_response.json()
+    return { "username": user_info['display_name'], "profile_pic": user_info['images'][0]['url'] }
 
-# this is just an example endpoint to show how to query info
+# this is just an example endpoint to show how to query info, this will get the users most listen to songs of the past 6 months
 @app.get("/user-top-songs")
 async def root():
     user_headers = {
@@ -92,6 +93,7 @@ async def root():
         "limit": 50,
         "time_range": "medium_term"
     }
-    user_tracks = requests.get("https://api.spotify.com/v1/me/top/tracks", params=user_params, headers=user_headers)
-    return { "songs": user_tracks.json() }
+    user_tracks_response = requests.get("https://api.spotify.com/v1/me/top/tracks", params=user_params, headers=user_headers)
+    user_tracks = user_tracks_response.json()
+    return { "songs": user_tracks['items'] }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+requests


### PR DESCRIPTION
This branch enables the backend to facilitate user authentication for spotify. It has endpoints for the login url, the spotify callback, and getting user info.

To test this branch you will need to checkout hot-reload-and-spotify-oauth branch for the app and the react-hot-reload branch for setup.

You will also need to download the credentials.json file from the shared google drive folder and place it into the /api folder.

Make sure you are following the adding packages setup instructions from the react-hot-reload branch because this branch adds new packages to the API.

Follow the instructions for testing spotify oauth in the pull request for app.

NOTE: The api is setup right now where only one user can use it at a time, this shouldn't be an issue until we deploy.